### PR TITLE
提高 rpc/README.md 的准确性

### DIFF
--- a/rpc/README.md
+++ b/rpc/README.md
@@ -105,7 +105,7 @@ message DownloadMsg {
   - protobuf
 
 最新版的[protobuf-gen-twirp](./cmd/protoc-gen-twirp)生成的 `*.twirp.go` 文件已经
-不再硬编码 `/twirp` 前缀。接口前缀可以通过 `RCP_PREFIX` 配置项控制，默认无前缀。
+不再硬编码 `/twirp` 前缀。接口前缀可以通过 `RPC_PREFIX` 配置项控制，默认前缀为 `/api`。
 
 表单请求
 ```


### PR DESCRIPTION
修正文档与实际代码不符的部分：
+ 默认 RPC 前缀应为 `"/api"`
+ 控制 RPC 前缀的配置项应为 `"RPC_PREFIX"`